### PR TITLE
Fix capstan setpoint fallthrough

### DIFF
--- a/src/main/java/frc/robot/subsystems/CapstanSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/CapstanSubsystem.java
@@ -182,9 +182,11 @@ public class CapstanSubsystem extends SubsystemBase {
             case kStore:
               elevatorCurrentTarget = ElevatorSetpoints.kStore;
               currentSetpoint = Setpoint.kStore;
+              break;
             case kProcessor:
               elevatorCurrentTarget = ElevatorSetpoints.kProcessor;
               currentSetpoint = Setpoint.kProcessor;
+              break;
             case kFeederStation:
               elevatorCurrentTarget = ElevatorSetpoints.kFeederStation;
               currentSetpoint = Setpoint.kFeederStation;


### PR DESCRIPTION
## Summary
- add the missing break statements in the capstan setpoint selector so Store and Processor keep their intended elevator targets

## Testing
- bash gradlew build --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e0640095488325b50d19014492c264