### PR TITLE
Fix MoveByDistanceCommand rotation setpoint

### DIFF
--- a/src/main/java/frc/robot/commands/MoveByDistanceCommand.java
+++ b/src/main/java/frc/robot/commands/MoveByDistanceCommand.java
@@ -59,7 +59,7 @@ public class MoveByDistanceCommand extends Command {
         //Setpoints
         xController.setSetpoint(targetX);
         yController.setSetpoint(targetY);
-        rotController.setSetpoint(Units.degreesToRadians(angleTOLERANCE));
+        rotController.setSetpoint(targetRot);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- update MoveByDistanceCommand to drive the rotation PID toward the computed target heading instead of a fixed tolerance value

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e06402b34883258735c11dec39655b